### PR TITLE
Use local net.Addr of incoming connections to dial out

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,6 @@ $ docker run -p 26000:26000 -d film42/turbulence:latest --config test/config.jso
 
 ### Configuring
 
-Turbluence only allows the listen port, proxy username, and proxy password to be configured:
-
 ```
 Usage of ./turbulence:
   -config string
@@ -34,6 +32,8 @@ Usage of ./turbulence:
         listen port (default 25000)
   -strip-proxy-headers
         strip proxy headers from http requests (default true)
+  -use-incoming-local-addr
+        Attempt to use the local address of the incoming connection when connecting upstream (default true)
   -username string
         username for proxy authentication
 ```
@@ -47,6 +47,7 @@ example config:
 {
   "port": 9000,
   "strip_proxy_headers": true,
+  "use_incoming_local_addr": true,
   "credentials": [
     {
       "username": "ron.swanson",

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ $ docker run -p 26000:26000 -d film42/turbulence:latest --config test/config.jso
 Usage of ./turbulence:
   -config string
         config file
+  -dial-timeout int
+         timeout for connecting to an upstream server in seconds (default 30)
   -password string
         password for proxy authentication
   -port int
@@ -33,7 +35,7 @@ Usage of ./turbulence:
   -strip-proxy-headers
         strip proxy headers from http requests (default true)
   -use-incoming-local-addr
-        Attempt to use the local address of the incoming connection when connecting upstream (default true)
+        attempt to use the local address of the incoming connection when connecting upstream (default true)
   -username string
         username for proxy authentication
 ```
@@ -48,6 +50,7 @@ example config:
   "port": 9000,
   "strip_proxy_headers": true,
   "use_incoming_local_addr": true,
+  "dial_timeout": 30,
   "credentials": [
     {
       "username": "ron.swanson",

--- a/config.go
+++ b/config.go
@@ -18,7 +18,7 @@ type Config struct {
 	StripProxyHeaders    bool `json:"strip_proxy_headers"`
 	Port                 int
 	UseIncomingLocalAddr bool `json:"use_incoming_local_addr"`
-	DialTimeout          int
+	DialTimeout          int  `json:"dial_timeout"`
 }
 
 func (config *Config) AuthenticationRequired() bool {

--- a/config.go
+++ b/config.go
@@ -14,10 +14,10 @@ type Credential struct {
 }
 
 type Config struct {
-	Credentials       []Credential
-	StripProxyHeaders bool `json:"strip_proxy_headers"`
-	Port              int
-	FollowLocalAddr   bool `json:"follow_local_addr"`
+	Credentials          []Credential
+	StripProxyHeaders    bool `json:"strip_proxy_headers"`
+	Port                 int
+	UseIncomingLocalAddr bool `json:"use_incoming_local_addr"`
 }
 
 func (config *Config) AuthenticationRequired() bool {

--- a/config.go
+++ b/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	StripProxyHeaders    bool `json:"strip_proxy_headers"`
 	Port                 int
 	UseIncomingLocalAddr bool `json:"use_incoming_local_addr"`
+	DialTimeout          int
 }
 
 func (config *Config) AuthenticationRequired() bool {

--- a/config.go
+++ b/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Credentials       []Credential
 	StripProxyHeaders bool `json:"strip_proxy_headers"`
 	Port              int
+	FollowLocalAddr   bool `json:"follow_local_addr"`
 }
 
 func (config *Config) AuthenticationRequired() bool {

--- a/config_test.go
+++ b/config_test.go
@@ -19,6 +19,10 @@ func TestLoadingConfigFromFile(t *testing.T) {
 		t.Fatal("Expected port to be 26000 but found:", sampleConfig.Port)
 	}
 
+	if sampleConfig.DialTimeout != 10 {
+		t.Fatal("Expected port to be 10 but found:", sampleConfig.DialTimeout)
+	}
+
 	if !sampleConfig.StripProxyHeaders {
 		t.Fatal("Expected sampleConfig.StripProxyHeaders to be true")
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -23,6 +23,10 @@ func TestLoadingConfigFromFile(t *testing.T) {
 		t.Fatal("Expected sampleConfig.StripProxyHeaders to be true")
 	}
 
+	if sampleConfig.UseIncomingLocalAddr {
+		t.Fatal("Expected sampleConfig.UseIncomingLocalAddr to be false")
+	}
+
 	if !sampleConfig.AuthenticationRequired() {
 		t.Fatal("Expected sample config to require authentication")
 	}

--- a/connection.go
+++ b/connection.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -24,21 +23,39 @@ type connection struct {
 }
 
 func (c *connection) Dial(network, address string) (net.Conn, error) {
-	if config.FollowLocalAddr {
-		dialer := &net.Dialer{LocalAddr: c.localAddr}
-
-		// Try to dial with the incoming LocalAddr to keep the incoming and outgoing IPs the same.
-		conn, err := dialer.Dial(network, address)
-		if err == nil {
-			return conn, nil
-		}
-
-		// If an error occurs, fallback to the default interface. This might happen if you connected
-		// via a loopback interace, like testing on the same machine. We should be more specifc about
-		// error handling, but falling back is fine for now.
-		logger.Warn.Println(c.id, "Ignoring net.Addr for", c.localAddr, "dialing due to error:", err)
+	if !config.FollowLocalAddr {
+		goto fallback
 	}
 
+	if c.localAddr == nil {
+		logger.Warn.Println(c.id, "Missing local net.Addr: a default local net.Addr will be used")
+		goto fallback
+	}
+
+	// Ensure the TCPAddr has its Port set to 0, which is way of telling the dialer to use
+	// and random port.
+	switch tcpAddr := c.localAddr.(type) {
+	case *net.TCPAddr:
+		tcpAddr.Port = 0
+	default:
+		logger.Warn.Println(c.id, "Ignoring local net.Addr", c.localAddr, "because TCPAddr was expected")
+		goto fallback
+	}
+
+	dialer := &net.Dialer{LocalAddr: c.localAddr}
+
+	// Try to dial with the incoming LocalAddr to keep the incoming and outgoing IPs the same.
+	conn, err := dialer.Dial(network, address)
+	if err == nil {
+		return conn, nil
+	}
+
+	// If an error occurs, fallback to the default interface. This might happen if you connected
+	// via a loopback interace, like testing on the same machine. We should be more specifc about
+	// error handling, but falling back is fine for now.
+	logger.Warn.Println(c.id, "Ignoring local net.Addr for", c.localAddr, "dialing due to error:", err)
+
+fallback:
 	return net.Dial(network, address)
 }
 
@@ -162,17 +179,6 @@ func newConnectionId() string {
 		return "[ERROR-MAKING-ID]"
 	}
 	return "[" + hex.EncodeToString(bytes) + "]"
-}
-
-func localAddrString(addr net.Addr) (string, error) {
-	switch a := addr.(type) {
-	case *net.TCPAddr:
-		return a.IP.String(), nil
-	case *net.IPAddr:
-		return a.IP.String(), nil
-	}
-
-	return "", errors.New("Could not find IP Address in net.Addr: " + addr.String())
 }
 
 func NewConnection(incoming net.Conn) (*connection, error) {

--- a/connection.go
+++ b/connection.go
@@ -29,10 +29,10 @@ func (c *connection) Dial(network, address string) (net.Conn, error) {
 			goto fallback
 		}
 
-		// Ensure the TCPAddr has its Port set to 0, which is way of telling the dialer to use
-		// and random port.
 		switch tcpAddr := c.localAddr.(type) {
 		case *net.TCPAddr:
+			// Ensure the TCPAddr has its Port set to 0, which is way of telling the dialer to
+			// use any random port. If you don't change this, you'll get a bind error.
 			tcpAddr.Port = 0
 		default:
 			logger.Warn.Println(c.id, "Ignoring local net.Addr", c.localAddr, "because net.TCPAddr was expected")

--- a/connection.go
+++ b/connection.go
@@ -179,7 +179,7 @@ func newConnectionId() string {
 	return "[" + hex.EncodeToString(bytes) + "]"
 }
 
-func NewConnection(incoming net.Conn) (*connection, error) {
+func NewConnection(incoming net.Conn) *connection {
 	newId := fmt.Sprint(newConnectionId(), " [", incoming.RemoteAddr().String(), "]")
 	localAddr := incoming.LocalAddr()
 
@@ -187,5 +187,5 @@ func NewConnection(incoming net.Conn) (*connection, error) {
 		id:        newId,
 		incoming:  incoming,
 		localAddr: localAddr,
-	}, nil
+	}
 }

--- a/connection.go
+++ b/connection.go
@@ -23,12 +23,12 @@ type connection struct {
 }
 
 func (c *connection) Dial(network, address string) (net.Conn, error) {
-	if c.localAddr == nil {
-		logger.Warn.Println(c.id, "Missing local net.Addr: a default local net.Addr will be used")
-		goto fallback
-	}
-
 	if config.UseIncomingLocalAddr {
+		if c.localAddr == nil {
+			logger.Warn.Println(c.id, "Missing local net.Addr: a default local net.Addr will be used")
+			goto fallback
+		}
+
 		// Ensure the TCPAddr has its Port set to 0, which is way of telling the dialer to use
 		// and random port.
 		switch tcpAddr := c.localAddr.(type) {

--- a/connection.go
+++ b/connection.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -95,6 +96,27 @@ func (c *connection) Close() {
 	}
 
 	logger.Info.Println(c.id, "Connection closed.")
+}
+
+func parseAddrFromHostport(hostport string) (string, error) {
+	if len(hostport) == 0 {
+		return "", errors.New("Hostport string provided was empty.")
+	}
+
+	colonIndex := strings.IndexByte(hostport, ':')
+	if colonIndex == -1 {
+		return "", errors.New("No colon was provided in the net.Conn local address (hostport string).")
+	}
+
+	if i := strings.Index(hostport, "]:"); i != -1 {
+		return hostport[:i+len("]")], nil
+	}
+
+	if strings.Contains(hostport, "]") {
+		return "", errors.New("Invalid ipv6 local address provided as hostport string.")
+	}
+
+	return hostport[:colonIndex], nil
 }
 
 // COPIED FROM STD LIB TO USE WITH PROXY-AUTH HEADER

--- a/connection.go
+++ b/connection.go
@@ -35,7 +35,7 @@ func (c *connection) Dial(network, address string) (net.Conn, error) {
 		case *net.TCPAddr:
 			tcpAddr.Port = 0
 		default:
-			logger.Warn.Println(c.id, "Ignoring local net.Addr", c.localAddr, "because TCPAddr was expected")
+			logger.Warn.Println(c.id, "Ignoring local net.Addr", c.localAddr, "because net.TCPAddr was expected")
 			goto fallback
 		}
 

--- a/connection_test.go
+++ b/connection_test.go
@@ -58,7 +58,7 @@ func TestInvalidCredentials(t *testing.T) {
 
 	incoming := NewMockConn()
 	defer incoming.CloseClient()
-	conn, _ := NewConnection(incoming)
+	conn := NewConnection(incoming)
 	go conn.Handle()
 
 	incoming.ClientWriter.Write([]byte(basicHttpProxyRequest()))
@@ -84,7 +84,7 @@ func TestSampleProxy(t *testing.T) {
 	cleanedUp := make(chan bool)
 	incoming := NewMockConn()
 	defer incoming.CloseClient()
-	conn, _ := NewConnection(incoming)
+	conn := NewConnection(incoming)
 	go func() {
 		conn.Handle()
 		cleanedUp <- true
@@ -114,7 +114,7 @@ func TestSampleProxyWithValidAuthCredentials(t *testing.T) {
 
 	cleanedUp := make(chan bool)
 	incoming := NewMockConn()
-	conn, _ := NewConnection(incoming)
+	conn := NewConnection(incoming)
 	go func() {
 		conn.Handle()
 		cleanedUp <- true
@@ -146,7 +146,7 @@ func TestSampleProxyViaConnect(t *testing.T) {
 
 	cleanedUp := make(chan bool)
 	incoming := NewMockConn()
-	conn, _ := NewConnection(incoming)
+	conn := NewConnection(incoming)
 	go func() {
 		conn.Handle()
 		cleanedUp <- true

--- a/connection_test.go
+++ b/connection_test.go
@@ -173,3 +173,35 @@ func TestSampleProxyViaConnect(t *testing.T) {
 	incoming.CloseClient()
 	<-cleanedUp
 }
+
+func TestParsingAddrFromHostport(t *testing.T) {
+	_, err := parseAddrFromHostport("")
+	if err == nil {
+		t.Fatal("Expected an error.")
+	}
+
+	_, err = parseAddrFromHostport("1.1.1.1")
+	if err == nil {
+		t.Fatal("Expected an error.")
+	}
+
+	_, err = parseAddrFromHostport("[2001:db8::1]")
+	if err == nil {
+		t.Fatal("Expected an error.")
+	}
+
+	_, err = parseAddrFromHostport("somerandomstring.com")
+	if err == nil {
+		t.Fatal("Expected an error.")
+	}
+
+	ipv4Addr, _ := parseAddrFromHostport("1.1.1.1:8000")
+	if ipv4Addr != "1.1.1.1" {
+		t.Fatalf("Expected 1.1.1.1 but found %s", ipv4Addr)
+	}
+
+	ipv6Addr, _ := parseAddrFromHostport("[2001:db8::1]:80")
+	if ipv6Addr != "[2001:db8::1]" {
+		t.Fatalf("Expected [2001:db8::1] but found %s", ipv6Addr)
+	}
+}

--- a/connection_test.go
+++ b/connection_test.go
@@ -58,7 +58,7 @@ func TestInvalidCredentials(t *testing.T) {
 
 	incoming := NewMockConn()
 	defer incoming.CloseClient()
-	conn := NewConnection(incoming)
+	conn, _ := NewConnection(incoming)
 	go conn.Handle()
 
 	incoming.ClientWriter.Write([]byte(basicHttpProxyRequest()))
@@ -84,7 +84,7 @@ func TestSampleProxy(t *testing.T) {
 	cleanedUp := make(chan bool)
 	incoming := NewMockConn()
 	defer incoming.CloseClient()
-	conn := NewConnection(incoming)
+	conn, _ := NewConnection(incoming)
 	go func() {
 		conn.Handle()
 		cleanedUp <- true
@@ -114,7 +114,7 @@ func TestSampleProxyWithValidAuthCredentials(t *testing.T) {
 
 	cleanedUp := make(chan bool)
 	incoming := NewMockConn()
-	conn := NewConnection(incoming)
+	conn, _ := NewConnection(incoming)
 	go func() {
 		conn.Handle()
 		cleanedUp <- true
@@ -146,7 +146,7 @@ func TestSampleProxyViaConnect(t *testing.T) {
 
 	cleanedUp := make(chan bool)
 	incoming := NewMockConn()
-	conn := NewConnection(incoming)
+	conn, _ := NewConnection(incoming)
 	go func() {
 		conn.Handle()
 		cleanedUp <- true
@@ -172,36 +172,4 @@ func TestSampleProxyViaConnect(t *testing.T) {
 
 	incoming.CloseClient()
 	<-cleanedUp
-}
-
-func TestParsingAddrFromHostport(t *testing.T) {
-	_, err := parseAddrFromHostport("")
-	if err == nil {
-		t.Fatal("Expected an error.")
-	}
-
-	_, err = parseAddrFromHostport("1.1.1.1")
-	if err == nil {
-		t.Fatal("Expected an error.")
-	}
-
-	_, err = parseAddrFromHostport("[2001:db8::1]")
-	if err == nil {
-		t.Fatal("Expected an error.")
-	}
-
-	_, err = parseAddrFromHostport("somerandomstring.com")
-	if err == nil {
-		t.Fatal("Expected an error.")
-	}
-
-	ipv4Addr, _ := parseAddrFromHostport("1.1.1.1:8000")
-	if ipv4Addr != "1.1.1.1" {
-		t.Fatalf("Expected 1.1.1.1 but found %s", ipv4Addr)
-	}
-
-	ipv6Addr, _ := parseAddrFromHostport("[2001:db8::1]:80")
-	if ipv6Addr != "[2001:db8::1]" {
-		t.Fatalf("Expected [2001:db8::1] but found %s", ipv6Addr)
-	}
 }

--- a/http.go
+++ b/http.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"strings"
 )
@@ -39,7 +38,7 @@ func (hp *httpProxy) SetupOutgoing(connection *connection, request *http.Request
 	}
 
 	// Create our outgoing connection.
-	outgoingConn, err := net.Dial("tcp", host)
+	outgoingConn, err := connection.Dial("tcp", host)
 	if err != nil {
 		return errors.New(fmt.Sprint("Error making outgoing request to", request.Host, err))
 	}

--- a/https.go
+++ b/https.go
@@ -3,7 +3,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 )
 
@@ -14,7 +13,7 @@ type httpsProxy struct{}
 func (hp *httpsProxy) SetupOutgoing(connection *connection, request *http.Request) error {
 	// Create our outgoing connection.
 	outgoingHost := request.URL.Host
-	outgoingConn, err := net.Dial("tcp", outgoingHost)
+	outgoingConn, err := connection.Dial("tcp", outgoingHost)
 	if err != nil {
 		return errors.New(fmt.Sprint("Error opening outgoing connection to", outgoingHost, err))
 	}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,8 @@ func main() {
 	configPtr := flag.String("config", "", "config file")
 	portPtr := flag.Int("port", 25000, "listen port")
 	stripProxyHeadersPtr := flag.Bool("strip-proxy-headers", true, "strip proxy headers from http requests")
-	useIncomingLocalAddr := flag.Bool("use-incoming-local-addr", true, "Attempt to use the local address of the incoming connection when connecting upstream")
+	useIncomingLocalAddr := flag.Bool("use-incoming-local-addr", true, "attempt to use the local address of the incoming connection when connecting upstream")
+	dialTimeoutPtr := flag.Int("dial-timeout", 30, " timeout for connecting to an upstream server in seconds")
 	usernamePtr := flag.String("username", "", "username for proxy authentication")
 	passwordPtr := flag.String("password", "", "password for proxy authentication")
 	flag.Parse()
@@ -77,6 +78,7 @@ func main() {
 			Port:                 *portPtr,
 			StripProxyHeaders:    *stripProxyHeadersPtr,
 			UseIncomingLocalAddr: *useIncomingLocalAddr,
+			DialTimeout:          *dialTimeoutPtr,
 		}
 
 		if *usernamePtr != "" {

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 	configPtr := flag.String("config", "", "config file")
 	portPtr := flag.Int("port", 25000, "listen port")
 	stripProxyHeadersPtr := flag.Bool("strip-proxy-headers", true, "strip proxy headers from http requests")
-	followLocalAddrPtr := flag.Bool("follow-local-addr", true, "Use the local address of the incoming connection when connecting upstream")
+	useIncomingLocalAddr := flag.Bool("use-incoming-local-addr", true, "Attempt to use the local address of the incoming connection when connecting upstream")
 	usernamePtr := flag.String("username", "", "username for proxy authentication")
 	passwordPtr := flag.String("password", "", "password for proxy authentication")
 	flag.Parse()
@@ -79,9 +79,9 @@ func main() {
 		configFile.Close()
 	} else {
 		config = &Config{
-			Port:              *portPtr,
-			StripProxyHeaders: *stripProxyHeadersPtr,
-			FollowLocalAddr:   *followLocalAddrPtr,
+			Port:                 *portPtr,
+			StripProxyHeaders:    *stripProxyHeadersPtr,
+			UseIncomingLocalAddr: *useIncomingLocalAddr,
 		}
 
 		if *usernamePtr != "" {

--- a/main.go
+++ b/main.go
@@ -10,12 +10,7 @@ import (
 var config *Config
 
 func handleConnection(conn net.Conn) {
-	connection, err := NewConnection(conn)
-	if err != nil {
-		logger.Fatal.Println(err)
-		return
-	}
-
+	connection := NewConnection(conn)
 	defer connection.Close()
 	connection.Handle()
 }

--- a/main.go
+++ b/main.go
@@ -10,7 +10,12 @@ import (
 var config *Config
 
 func handleConnection(conn net.Conn) {
-	connection := NewConnection(conn)
+	connection, err := NewConnection(conn)
+	if err != nil {
+		logger.Fatal.Println(err)
+		return
+	}
+
 	defer connection.Close()
 	connection.Handle()
 }

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func main() {
 	configPtr := flag.String("config", "", "config file")
 	portPtr := flag.Int("port", 25000, "listen port")
 	stripProxyHeadersPtr := flag.Bool("strip-proxy-headers", true, "strip proxy headers from http requests")
+	followLocalAddrPtr := flag.Bool("follow-local-addr", true, "Use the local address of the incoming connection when connecting upstream")
 	usernamePtr := flag.String("username", "", "username for proxy authentication")
 	passwordPtr := flag.String("password", "", "password for proxy authentication")
 	flag.Parse()
@@ -80,6 +81,7 @@ func main() {
 		config = &Config{
 			Port:              *portPtr,
 			StripProxyHeaders: *stripProxyHeadersPtr,
+			FollowLocalAddr:   *followLocalAddrPtr,
 		}
 
 		if *usernamePtr != "" {

--- a/mock_test.go
+++ b/mock_test.go
@@ -6,20 +6,6 @@ import (
 	"time"
 )
 
-// Addr is a fake network interface which implements the net.Addr interface
-type Addr struct {
-	NetworkString string
-	AddrString    string
-}
-
-func (a Addr) Network() string {
-	return a.NetworkString
-}
-
-func (a Addr) String() string {
-	return a.AddrString
-}
-
 type MockConn struct {
 	ServerReader *io.PipeReader
 	ServerWriter *io.PipeWriter
@@ -51,16 +37,18 @@ func (c MockConn) Read(data []byte) (n int, err error)  { return c.ServerReader.
 func (c MockConn) Write(data []byte) (n int, err error) { return c.ServerWriter.Write(data) }
 
 func (c MockConn) LocalAddr() net.Addr {
-	return Addr{
-		NetworkString: "tcp",
-		AddrString:    "127.0.0.1",
+	return &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1:2342"),
+		Port: 2342,
+		Zone: "",
 	}
 }
 
 func (c MockConn) RemoteAddr() net.Addr {
-	return Addr{
-		NetworkString: "tcp",
-		AddrString:    "127.0.0.1",
+	return &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1:2342"),
+		Port: 2342,
+		Zone: "",
 	}
 }
 

--- a/test/config.json
+++ b/test/config.json
@@ -2,6 +2,7 @@
   "port": 26000,
   "strip_proxy_headers": true,
   "use_incoming_local_addr": false,
+  "dial_timeout": 10,
   "credentials": [
     {
       "username": "login",

--- a/test/config.json
+++ b/test/config.json
@@ -1,6 +1,7 @@
 {
   "port": 26000,
   "strip_proxy_headers": true,
+  "use_incoming_local_addr": false,
   "credentials": [
     {
       "username": "login",


### PR DESCRIPTION
This is useful on a machine with multiple interfaces (IP addresses). So instead of dialing a new connection on the default interface, we ask the incoming connection about the interface it arrived on and attempt to open a new connection from the same interface. In other words, this tries to make the "destination ip" of the incoming connection become the "source ip" of the outgoing connection.

This doesn't works basically all the time unless you're attempting to make a request to turbulence from localhost. To avoid errors, turbulence will log an warning and fallback to the default interface should anything bad happen. This also lets us keep the fast-path fast. If someone doesn't need this behavior, they can disable in the config file, or via CLI flag and things will function as they were before this patch.