### PR TITLE
Switch to using binary entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ ADD . /turbulence
 WORKDIR /turbulence
 ENV GOPATH /turbulence
 RUN go build
-ENTRYPOINT ["/bin/sh", "-c", "/turbulence/turbulence ${*}", "--"]
+ENTRYPOINT ["/turbulence/turbulence"]


### PR DESCRIPTION
We don't need no bash script middleman.
We don't need no shell control.
No weird hacks inside the container.
Bash scripts, leave that binary alone!